### PR TITLE
add `rocksdb_property_get()`

### DIFF
--- a/include/rocksdb.h
+++ b/include/rocksdb.h
@@ -712,6 +712,9 @@ rocksdb_stats_level_get(rocksdb_t *db, rocksdb_stats_level_t *level);
 int
 rocksdb_stats_level_set(rocksdb_t *db, rocksdb_stats_level_t level);
 
+int
+rocksdb_property_value(rocksdb_t *db, const char *name, rocksdb_slice_t *value);
+
 rocksdb_column_family_descriptor_t
 rocksdb_column_family_descriptor(const char *name, const rocksdb_column_family_options_t *options);
 

--- a/include/rocksdb.h
+++ b/include/rocksdb.h
@@ -713,7 +713,7 @@ int
 rocksdb_stats_level_set(rocksdb_t *db, rocksdb_stats_level_t level);
 
 int
-rocksdb_property_value(rocksdb_t *db, const char *name, rocksdb_slice_t *value);
+rocksdb_property_get(rocksdb_t *db, const char *name, rocksdb_slice_t *value);
 
 rocksdb_column_family_descriptor_t
 rocksdb_column_family_descriptor(const char *name, const rocksdb_column_family_options_t *options);

--- a/src/rocksdb.cc
+++ b/src/rocksdb.cc
@@ -1537,6 +1537,21 @@ rocksdb_stats_level_set(rocksdb_t *db, rocksdb_stats_level_t level) {
   return 0;
 }
 
+extern "C" int
+rocksdb_property_value(rocksdb_t *db, const char *name, rocksdb_slice_t *value) {
+  auto handle = reinterpret_cast<DB *>(db->handle);
+
+  std::string property;
+  if (!handle->GetProperty(name, &property)) {
+    *value = rocksdb_slice_empty();
+    return UV_ENOENT;
+  }
+
+  *value = rocksdb_slice_init(strdup(property.c_str()), property.size());
+
+  return 0;
+}
+
 extern "C" rocksdb_column_family_descriptor_t
 rocksdb_column_family_descriptor(const char *name, const rocksdb_column_family_options_t *options) {
   rocksdb_column_family_descriptor_t descriptor;

--- a/src/rocksdb.cc
+++ b/src/rocksdb.cc
@@ -1538,16 +1538,18 @@ rocksdb_stats_level_set(rocksdb_t *db, rocksdb_stats_level_t level) {
 }
 
 extern "C" int
-rocksdb_property_value(rocksdb_t *db, const char *name, rocksdb_slice_t *value) {
+rocksdb_property_get(rocksdb_t *db, const char *name, rocksdb_slice_t *value) {
   auto handle = reinterpret_cast<DB *>(db->handle);
 
   std::string property;
   if (!handle->GetProperty(name, &property)) {
-    *value = rocksdb_slice_empty();
     return UV_ENOENT;
   }
 
-  *value = rocksdb_slice_init(strdup(property.c_str()), property.size());
+  auto data = malloc(property.size());
+  memcpy(data, property.data(), property.size());
+
+  *value = rocksdb_slice_init(static_cast<char *>(data), property.size());
 
   return 0;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ list(APPEND tests
   write-read
   write-read-snapshot
   write-read-sync
+  property-get
 )
 
 foreach(test IN LISTS tests)

--- a/test/property-get.c
+++ b/test/property-get.c
@@ -1,0 +1,89 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+#include <uv.h>
+
+#include "../include/rocksdb.h"
+
+static uv_loop_t *loop;
+
+static rocksdb_t db;
+static rocksdb_column_family_t *family;
+
+static void
+on_close(rocksdb_close_t *req, int status) {
+  assert(status == 0);
+
+  assert(req->error == NULL);
+
+  rocksdb_close_cleanup(req);
+}
+
+static void
+on_write(rocksdb_write_batch_t *req, int status) {
+  int e;
+  assert(status == 0);
+
+  rocksdb_slice_t value = rocksdb_slice_empty();
+
+  e = rocksdb_property_get(&db, "rocksdb.options-statistics", &value);
+  assert(e == 0);
+  assert(value.len > 0);
+
+  static const char header[] = "rocksdb.block.cache.miss COUNT : 0";
+  assert(memcmp(value.data, header, sizeof(header) - 1) == 0);
+
+  rocksdb_slice_destroy(&value);
+
+  e = rocksdb_column_family_destroy(&db, family);
+  assert(e == 0);
+
+  static rocksdb_close_t close;
+  e = rocksdb_close(&db, &close, NULL, on_close);
+  assert(e == 0);
+
+  rocksdb_write_cleanup(req);
+}
+
+static void
+on_open(rocksdb_open_t *req, int status) {
+  int e;
+
+  assert(status == 0);
+
+  assert(req->error == NULL);
+
+  static rocksdb_write_t write;
+  write.type = rocksdb_put;
+  write.column_family = family;
+  write.key = rocksdb_slice_init("hello", 5);
+  write.value = rocksdb_slice_init("world", 6);
+
+  static rocksdb_write_batch_t batch;
+  e = rocksdb_write(&db, &batch, &write, 1, NULL, on_write);
+  assert(e == 0);
+
+  rocksdb_open_cleanup(req);
+}
+
+int
+main() {
+  int e;
+
+  loop = uv_default_loop();
+
+  rocksdb_options_t options = {
+    .version = 6,
+    .create_if_missing = true,
+    .enable_statistics = true
+  };
+
+  rocksdb_column_family_descriptor_t descriptor = rocksdb_column_family_descriptor("default", NULL);
+
+  static rocksdb_open_t open;
+  e = rocksdb_open(loop, &db, &open, "test/fixtures/property-get.db", &options, &descriptor, &family, 1, NULL, on_open);
+  assert(e == 0);
+
+  e = uv_run(loop, UV_RUN_DEFAULT);
+  assert(e == 0);
+}


### PR DESCRIPTION
Wish to expose statistics in rocksdb-native but I forgot to export the actual call in the previous pr #29 
```c
handle->GetProperty("rocksdb.options-statistics")
```
With this pr,  statistics can be enabled and read. 